### PR TITLE
Add clinic data fetch util

### DIFF
--- a/frontend/src/brain/Brain.ts
+++ b/frontend/src/brain/Brain.ts
@@ -156,4 +156,29 @@ export class Brain<SecurityDataType = unknown> extends HttpClient<SecurityDataTy
       type: ContentType.Json,
       ...params,
     });
+
+  /**
+   * @description Trigger processing of all clinics
+   * @request GET:/routes/process-clinics
+   */
+  process_clinics = (params: RequestParams = {}) =>
+    this.request<any, any>({
+      path: `/routes/process-clinics`,
+      method: "GET",
+      ...params,
+    });
+
+  /**
+   * @description Download aggregated clinic data
+   * @request GET:/routes/download-aggregated/{json_key}
+   */
+  download_aggregated_json = (
+    { jsonKey }: DownloadAggregatedParams,
+    params: RequestParams = {}
+  ) =>
+    this.request<DownloadAggregatedData, DownloadAggregatedError>({
+      path: `/routes/download-aggregated/${jsonKey}`,
+      method: "GET",
+      ...params,
+    });
 }

--- a/frontend/src/brain/BrainRoute.ts
+++ b/frontend/src/brain/BrainRoute.ts
@@ -8,6 +8,7 @@ import {
   ListCustomersData,
   ProcessRequest,
   ProcessSalesDataEndpointData,
+  DownloadAggregatedData,
   RunDataExtractionData,
 } from "./data-contracts";
 
@@ -156,5 +157,29 @@ export namespace Brain {
     export type RequestBody = ProcessRequest;
     export type RequestHeaders = {};
     export type ResponseBody = ProcessSalesDataEndpointData;
+  }
+
+  /**
+   * @name process_clinics
+   * @request GET:/routes/process-clinics
+   */
+  export namespace process_clinics {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = any;
+  }
+
+  /**
+   * @name download_aggregated_json
+   * @request GET:/routes/download-aggregated/{json_key}
+   */
+  export namespace download_aggregated_json {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = DownloadAggregatedData;
   }
 }

--- a/frontend/src/brain/data-contracts.ts
+++ b/frontend/src/brain/data-contracts.ts
@@ -132,3 +132,13 @@ export type DownloadJsonError = HTTPValidationError;
 export type ProcessSalesDataEndpointData = Record<string, any>;
 
 export type ProcessSalesDataEndpointError = HTTPValidationError;
+
+export interface DownloadAggregatedParams {
+  /** Json Key */
+  jsonKey: string;
+}
+
+export type DownloadAggregatedData = any;
+
+export type DownloadAggregatedError = HTTPValidationError;
+

--- a/frontend/src/utils/clinic-data.ts
+++ b/frontend/src/utils/clinic-data.ts
@@ -1,0 +1,75 @@
+import brain from "brain";
+
+/**
+ * Fetches aggregated clinic data by triggering backend processing
+ * and polling for completion.
+ * @param setIsLoading - Optional loading state setter
+ * @param setError - Optional error state setter
+ * @returns Promise resolving to the aggregated clinic JSON data
+ */
+export const fetchClinicData = async (
+  setIsLoading?: (loading: boolean) => void,
+  setError?: (error: string | null) => void
+): Promise<any> => {
+  if (setIsLoading) setIsLoading(true);
+  if (setError) setError(null);
+
+  try {
+    // Step 1: Start clinic processing
+    const startResponse = await brain.process_clinics();
+    if (!startResponse.ok) {
+      throw new Error(
+        `Failed to start clinic processing: ${startResponse.status} ${startResponse.statusText}`
+      );
+    }
+
+    const startData = await startResponse.json();
+    const taskId = startData.task_id as string | undefined;
+    if (!taskId) {
+      throw new Error("No task ID returned from process-clinics endpoint");
+    }
+
+    // Step 2: Poll task status until completion
+    let statusData: any = null;
+    for (let attempts = 0; attempts < 60; attempts++) {
+      await new Promise((r) => setTimeout(r, 2000));
+
+      const statusResponse = await brain.get_task_status({ taskId });
+      if (!statusResponse.ok) {
+        throw new Error(
+          `Failed to fetch task status: ${statusResponse.status} ${statusResponse.statusText}`
+        );
+      }
+      statusData = await statusResponse.json();
+
+      if (statusData.status === "completed" || statusData.status === "failed") {
+        break;
+      }
+    }
+
+    if (!statusData || statusData.status !== "completed" || !statusData.json_key) {
+      const reason = statusData?.error || "Task did not complete successfully";
+      throw new Error(`Clinic processing failed: ${reason}`);
+    }
+
+    const jsonKey = statusData.json_key as string;
+
+    // Step 3: Download aggregated JSON
+    const dataResponse = await brain.download_aggregated_json({ jsonKey });
+    if (!dataResponse.ok) {
+      throw new Error(
+        `Failed to download aggregated data: ${dataResponse.status} ${dataResponse.statusText}`
+      );
+    }
+
+    return await dataResponse.json();
+  } catch (err) {
+    console.error("Error fetching clinic data:", err);
+    if (setError) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+    throw err;
+  } finally {
+    if (setIsLoading) setIsLoading(false);
+  }
+};


### PR DESCRIPTION
## Summary
- support clinic data processing endpoints in brain client
- implement `fetchClinicData` helper

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react-router-dom' etc.)*